### PR TITLE
Fix for IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -13,7 +13,7 @@
   ],
   "plugins": [
     ["transform-runtime", {
-      "helpers": false,
+      "helpers": true,
       "polyfill": true,
       "regenerator": true,
       "moduleName": "babel-runtime"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   ],
   "dependencies": {
     "@gmod/bgzf-filehandle": "^1.2.2",
-    "util.promisify": "^1.0.0"
+    "es6-promisify": "^6.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,4 +1,4 @@
-const {promisify} = require('es6-promisify')
+const { promisify } = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/test/lib/io/localFile.js
+++ b/test/lib/io/localFile.js
@@ -1,4 +1,4 @@
-const promisify = require('util.promisify')
+const {promisify} = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase

--- a/test/lib/io/localFile.js
+++ b/test/lib/io/localFile.js
@@ -1,4 +1,4 @@
-const {promisify} = require('es6-promisify')
+const { promisify } = require('es6-promisify')
 
 // don't load fs native module if running in webpacked code
 const fs = typeof __webpack_require__ !== 'function' ? require('fs') : null // eslint-disable-line camelcase


### PR DESCRIPTION
This changes to use es6-promisify because util.promisify can result in Object.defineProperty length which seems un-babel-ifiable