### PR TITLE
Update README to refer to getSequenceList instead of getSequenceNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![NPM version](https://img.shields.io/npm/v/@gmod/indexedfasta.svg?style=flat-square)](https://npmjs.org/package/@gmod/indexedfasta)
 [![Build Status](https://img.shields.io/travis/GMOD/indexedfasta-js/master.svg?style=flat-square)](https://travis-ci.org/GMOD/indexedfasta-js) [![Coverage Status](https://img.shields.io/codecov/c/github/GMOD/indexedfasta-js/master.svg?style=flat-square)](https://codecov.io/gh/GMOD/indexedfasta-js/branch/master) [![Greenkeeper badge](https://badges.greenkeeper.io/GMOD/indexedfasta-js.svg)](https://greenkeeper.io/)
 
-
 ## Install
 
     $ npm install --save @gmod/indexedfasta
@@ -10,37 +9,37 @@
 ## Usage
 
 ```js
-const { IndexedFasta, BgzipIndexedFasta } = require('@gmod/indexedfasta')
+const { IndexedFasta, BgzipIndexedFasta } = require("@gmod/indexedfasta");
 
 const t = new IndexedFasta({
-  path: 'test.fa',
-  faiPath: 'test.fa.fai',
+  path: "test.fa",
+  faiPath: "test.fa.fai"
 });
 // or
 const t = new BgzipIndexedFasta({
-  path: 'test.fa.gz',
-  faiPath: 'test.fa.gz.fai',
-  gziPath: 'test.fa.gz.gzi',
+  path: "test.fa.gz",
+  faiPath: "test.fa.gz.fai",
+  gziPath: "test.fa.gz.gzi",
   chunkSizeLimit: 500000
 });
 
 // get the first 10 bases of a sequence from the file.
 // coordinates are UCSC standard 0-based half-open
 //
-const chr1Region = await t.getSequence('chr1', 0, 10);
+const chr1Region = await t.getSequence("chr1", 0, 10);
 // chr1Region is now a string of bases, 'ACTG...'
 
 // get a whole sequence from the file
-const chr1Bases = await t.getSequence('chr1');
+const chr1Bases = await t.getSequence("chr1");
 
 // get object with all seq lengths as { seqName => length, ... }
 const allSequenceSizes = await t.getSequenceSizes();
 
 // get the size of a single sequence
-const chr1Size = await t.getSequenceSize('chr1');
+const chr1Size = await t.getSequenceSize("chr1");
 
 // get an array of all sequence names in the file
-const seqNames = await t.getSequenceNames();
+const seqNames = await t.getSequenceList();
 ```
 
 ## Academic Use

--- a/src/indexedFasta.js
+++ b/src/indexedFasta.js
@@ -81,10 +81,9 @@ class IndexedFasta {
   }
 
   /**
-   * @returns {array[string]} array of string sequence
-   * names that are present in the index, in which the
-   * array index indicates the sequence ID, and the value
-   * is the sequence name
+   * @returns {array[string]} array of string sequence ids that are internally
+   * used in the code. use getSequenceList for real sequence names (sorry for
+   * the confusing names!)
    */
   async getSequenceNames() {
     return Object.keys((await this._getIndexes()).id)


### PR DESCRIPTION
Fixes #49 

I propose not changing the behavior, to avoid a major version bump, and just updating the docs.

Alternatively, we could fix the API more properly and actually return sequence names from getSequenceNames but it might be ok like this