### PR TITLE
49 get sequence names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 dist
 *.log
 .vscode/
+.eslintcache

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ class FetchableSmallFasta {
     return entry.sequence.substr(start, length)
   }
 
-  async getSequenceList() {
+  async getSequenceNames() {
     const data = await this.data
     return data.map(entry => entry.id)
   }

--- a/src/indexedFasta.js
+++ b/src/indexedFasta.js
@@ -71,30 +71,6 @@ class IndexedFasta {
   }
 
   /**
-   * @typedef {Object} Sequence
-   * @property {number} id - The sequence ID
-   * @property {string} name - The sequence name
-   * @property {number} start - The start coordinate of the sequence
-   * @property {number} end - The end coordinate of the sequence
-   * @property {number} length - The length of the sequence
-   * @property {number} lineBytes - The total number of bytes in each sequence
-   * line (including newlines)
-   * @property {number} lineLength - The total sequence length in each sequence
-   * line
-   * @property {number} offset - The number of bytes offset from the beginning
-   * of the block the first sequence line starts
-   */
-
-  /**
-   * @returns {array[Sequence]} array of sequences that are present in the
-   * index, in which the array index indicates the sequence ID, and the value
-   * is the sequence object
-   */
-  async getSequenceList() {
-    return Object.values((await this._getIndexes()).id)
-  }
-
-  /**
    * @returns {array[string]} array of string sequence
    * names that are present in the index, in which the
    * array index indicates the sequence ID, and the value

--- a/src/indexedFasta.js
+++ b/src/indexedFasta.js
@@ -71,13 +71,27 @@ class IndexedFasta {
   }
 
   /**
-   * @returns {array[string]} array of string sequence
-   * names that are present in the index, in which the
-   * array index indicates the sequence ID, and the value
-   * is the sequence name
+   * @typedef {Object} Sequence
+   * @property {number} id - The sequence ID
+   * @property {string} name - The sequence name
+   * @property {number} start - The start coordinate of the sequence
+   * @property {number} end - The end coordinate of the sequence
+   * @property {number} length - The length of the sequence
+   * @property {number} lineBytes - The total number of bytes in each sequence
+   * line (including newlines)
+   * @property {number} lineLength - The total sequence length in each sequence
+   * line
+   * @property {number} offset - The number of bytes offset from the beginning
+   * of the block the first sequence line starts
+   */
+
+  /**
+   * @returns {array[Sequence]} array of sequences that are present in the
+   * index, in which the array index indicates the sequence ID, and the value
+   * is the sequence object
    */
   async getSequenceList() {
-    return Object.values((await this._getIndexes()).id).map(value => value.name)
+    return Object.values((await this._getIndexes()).id)
   }
 
   /**

--- a/src/indexedFasta.js
+++ b/src/indexedFasta.js
@@ -87,7 +87,7 @@ class IndexedFasta {
    * is the sequence name
    */
   async getSequenceNames() {
-    return Object.keys((await this._getIndexes()).id)
+    return Object.keys((await this._getIndexes()).name)
   }
 
   /**

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -16,6 +16,18 @@ async function phiTest(t) {
   const catchErr = e => {
     err = e
   }
+  expect(await t.getSequenceList()).toEqual([
+    {
+      end: 5386,
+      id: 0,
+      length: 5386,
+      lineBytes: 71,
+      lineLength: 70,
+      name: 'NC_001422.1',
+      offset: 49,
+      start: 0,
+    },
+  ])
   expect(await t.getSequenceNames()).toEqual(['NC_001422.1'])
   expect(await t.getSequenceSizes()).toEqual({ 'NC_001422.1': 5386 })
   expect(await t.getResiduesByName('NC_001422.1', 0, 100)).toEqual(
@@ -30,6 +42,18 @@ async function phiTest(t) {
 }
 
 async function endTest(t) {
+  expect(await t.getSequenceList()).toEqual([
+    {
+      end: 100100,
+      id: 0,
+      length: 100100,
+      lineBytes: 101,
+      lineLength: 100,
+      name: 'chr1',
+      offset: 6,
+      start: 0,
+    },
+  ])
   expect(await t.getSequenceNames()).toEqual(['chr1'])
   expect(await t.getSequenceSizes()).toEqual({ chr1: 100100 })
   expect(await t.getResiduesByName('chr1', 100000, 100100)).toEqual(
@@ -44,6 +68,28 @@ async function endTest(t) {
 }
 
 async function volvoxTest(t) {
+  expect(await t.getSequenceList()).toEqual([
+    {
+      end: 50001,
+      id: 0,
+      length: 50001,
+      lineBytes: 61,
+      lineLength: 60,
+      name: 'ctgA',
+      offset: 6,
+      start: 0,
+    },
+    {
+      end: 6079,
+      id: 1,
+      length: 6079,
+      lineBytes: 101,
+      lineLength: 100,
+      name: 'ctgB',
+      offset: 50847,
+      start: 0,
+    },
+  ])
   expect(await t.getSequenceNames()).toEqual(['ctgA', 'ctgB'])
   expect(await t.getSequenceSize('ctgA')).toEqual(50001)
   expect(await t.getSequenceSize('ctgC')).toEqual(undefined)

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -5,7 +5,7 @@ const { testDataFile } = require('./lib/util')
 describe('FASTA parser', () => {
   it('process unindexed fasta', async () => {
     const t = new FetchableSmallFasta({ fasta: testDataFile('phi-X174.fa') })
-    expect(await t.getSequenceList()).toEqual(['NC_001422.1'])
+    expect(await t.getSequenceNames()).toEqual(['NC_001422.1'])
     expect(await t.fetch('NC_001422.1', 0, 100)).toEqual(
       'GAGTTTTATCGCTTCCATGACGCAGAAGTTAACACTTTCGGATATTTCTGATGAGTCGAAAAATTATCTTGATAAAGCAGGAATTACTACTGCTTGTTTA',
     )
@@ -16,7 +16,7 @@ async function phiTest(t) {
   const catchErr = e => {
     err = e
   }
-  expect(await t.getSequenceList()).toEqual(['NC_001422.1'])
+  expect(await t.getSequenceNames()).toEqual(['NC_001422.1'])
   expect(await t.getSequenceSizes()).toEqual({ 'NC_001422.1': 5386 })
   expect(await t.getResiduesByName('NC_001422.1', 0, 100)).toEqual(
     'GAGTTTTATCGCTTCCATGACGCAGAAGTTAACACTTTCGGATATTTCTGATGAGTCGAAAAATTATCTTGATAAAGCAGGAATTACTACTGCTTGTTTA',
@@ -30,7 +30,7 @@ async function phiTest(t) {
 }
 
 async function endTest(t) {
-  expect(await t.getSequenceList()).toEqual(['chr1'])
+  expect(await t.getSequenceNames()).toEqual(['chr1'])
   expect(await t.getSequenceSizes()).toEqual({ chr1: 100100 })
   expect(await t.getResiduesByName('chr1', 100000, 100100)).toEqual(
     'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -44,7 +44,7 @@ async function endTest(t) {
 }
 
 async function volvoxTest(t) {
-  expect(await t.getSequenceList()).toEqual(['ctgA', 'ctgB'])
+  expect(await t.getSequenceNames()).toEqual(['ctgA', 'ctgB'])
   expect(await t.getSequenceSize('ctgA')).toEqual(50001)
   expect(await t.getSequenceSize('ctgC')).toEqual(undefined)
   expect(await t.getSequenceSizes()).toEqual({ ctgA: 50001, ctgB: 6079 })

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -16,18 +16,7 @@ async function phiTest(t) {
   const catchErr = e => {
     err = e
   }
-  expect(await t.getSequenceList()).toEqual([
-    {
-      end: 5386,
-      id: 0,
-      length: 5386,
-      lineBytes: 71,
-      lineLength: 70,
-      name: 'NC_001422.1',
-      offset: 49,
-      start: 0,
-    },
-  ])
+
   expect(await t.getSequenceNames()).toEqual(['NC_001422.1'])
   expect(await t.getSequenceSizes()).toEqual({ 'NC_001422.1': 5386 })
   expect(await t.getResiduesByName('NC_001422.1', 0, 100)).toEqual(
@@ -42,18 +31,6 @@ async function phiTest(t) {
 }
 
 async function endTest(t) {
-  expect(await t.getSequenceList()).toEqual([
-    {
-      end: 100100,
-      id: 0,
-      length: 100100,
-      lineBytes: 101,
-      lineLength: 100,
-      name: 'chr1',
-      offset: 6,
-      start: 0,
-    },
-  ])
   expect(await t.getSequenceNames()).toEqual(['chr1'])
   expect(await t.getSequenceSizes()).toEqual({ chr1: 100100 })
   expect(await t.getResiduesByName('chr1', 100000, 100100)).toEqual(
@@ -68,28 +45,6 @@ async function endTest(t) {
 }
 
 async function volvoxTest(t) {
-  expect(await t.getSequenceList()).toEqual([
-    {
-      end: 50001,
-      id: 0,
-      length: 50001,
-      lineBytes: 61,
-      lineLength: 60,
-      name: 'ctgA',
-      offset: 6,
-      start: 0,
-    },
-    {
-      end: 6079,
-      id: 1,
-      length: 6079,
-      lineBytes: 101,
-      lineLength: 100,
-      name: 'ctgB',
-      offset: 50847,
-      start: 0,
-    },
-  ])
   expect(await t.getSequenceNames()).toEqual(['ctgA', 'ctgB'])
   expect(await t.getSequenceSize('ctgA')).toEqual(50001)
   expect(await t.getSequenceSize('ctgC')).toEqual(undefined)


### PR DESCRIPTION
Alternative to #50 

* Makes `getSequenceNames()` return a list of sequence names as strings
* Makes `getSequenceList()` return a list of sequence objects

Fixes #49 